### PR TITLE
Update to latest version of intake-esm using pip

### DIFF
--- a/environments/cloud_env.yaml
+++ b/environments/cloud_env.yaml
@@ -67,7 +67,6 @@ dependencies:
   # intake-related
   - intake
   - intake-xarray
-  - intake-esm
   - intake-stac
   # zarr-related
   - zarr
@@ -108,4 +107,4 @@ dependencies:
     - git+https://github.com/jbusecke/xgcm.git@jbusecke_weighted_average_and_cumsum
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master
-    - git+https://github.com/andersy005/intake-esm.git@refactor
+    - intake-esm

--- a/environments/ncar-env/environment.yaml
+++ b/environments/ncar-env/environment.yaml
@@ -37,7 +37,6 @@ dependencies:
 - holoviews
 - hvplot
 - intake
-# - intake-esm # pending merge of git+https://github.com/andersy005/intake-esm.git@refactor#egg=intake-esm
 - intake-stac
 - intake-xarray
 - ipyleaflet
@@ -118,3 +117,4 @@ dependencies:
   - git+https://github.com/andersy005/intake-esm.git@refactor#egg=intake-esm
   - graphviz
   - ncar-jobqueue
+  - intake-esm

--- a/environments/r2d_env/pangeo_notebook_env.yaml
+++ b/environments/r2d_env/pangeo_notebook_env.yaml
@@ -45,7 +45,6 @@ dependencies:
   # intake-related
   - intake
   - intake-xarray
-  - intake-esm
   # - intake-stac
   # zarr-related
   - zarr
@@ -65,3 +64,5 @@ dependencies:
   - pytide
   - pyinterp
   - pip
+  - pip:
+    - intake-esm


### PR DESCRIPTION
Because anaconda is slow and latest version (`2019.10.15`) still isn't available