### PR TITLE
fix dask-kubernetes pinned version

### DIFF
--- a/environments/cloud_env.yaml
+++ b/environments/cloud_env.yaml
@@ -16,7 +16,7 @@ dependencies:
   - nbgitpuller=0.7
   - dask>=2.5.2
   - distributed>=2.5
-  - dask-kubernetes>=0.92
+  - dask-kubernetes>=0.9.2
   - dask-gateway>=0.5
   - tornado=6
   - jupyter-server-proxy=1.1


### PR DESCRIPTION
- should be 0.9.2 instead of 0.92. `conda create env` fails with 0.92 b/c max version is 0.10